### PR TITLE
feat(#12): Modal Component

### DIFF
--- a/src/components/modal/Modal.module.scss
+++ b/src/components/modal/Modal.module.scss
@@ -1,0 +1,33 @@
+.dimmed {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal {
+  display: flex;
+  flex-direction: column;
+  width: 90%;
+  max-height: 70%;
+  padding: 24px;
+  background-color: #FFF;
+  box-sizing: border-box;
+  color: #000;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.body {
+  overflow: auto;
+}
+

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,0 +1,32 @@
+import { FC, ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './Modal.module.scss';
+
+interface ModalProps {
+  body: ReactNode;
+  footer?: ReactNode;
+  onClose?: () => void;
+}
+
+export const Modal: FC<ModalProps> = ({
+  body,
+  footer,
+  onClose
+}) => {
+  return createPortal(
+    <div className={styles.dimmed} onClick={onClose}>
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <button type="button" onClick={onClose}>X</button>
+        </div>
+        <div className={styles.body}>
+          { body }
+        </div>
+        <div className={styles.footer}>
+          { footer }
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};


### PR DESCRIPTION
## 📋 PR 내용
프로젝트 공용으로 사용할 **Modal 컴퍼넌트**를 제작했습니다.
스타일은 최소한으로 작업했습니다. 못생겨도 이해 부탁드려요..!


## 🔍 작업 상세 내용
### `Modal.tsx`
Modal의 기본 UI만을 제공합니다. 모달을 사용하는 컴퍼넌트에서 내용의 기능, 스타일, 내부 로직을 담당하는 방향으로 제작했습니다.

- *ModalProps*
  - `body`: 내용
  - `footer`: 모달의 하단에 위치하며, 주로 버튼이 포함됩니다.
  - `onClick`: 모달을 닫을 때 사용. 딤드와 X버튼 클릭 시 호출됩니다.

🐥 와이어프레임 상으로 header가 필요없을 듯하여 props를 만들지 않았습니다. 필요에 따라 언제든 추가 가능합니다!

## 🔗 관련 이슈
Closes #12


## ✅ 체크리스트
- [x] 코드가 빌드되고, 오류 없이 실행되나요?
- [ ] 관련 테스트 코드를 작성하고 통과했나요?
- [x] 코드 스타일을 준수했나요? (EsLint, Prettier 등)



## 🐥 의견
`className={styles.XXX}`가 반복되니 보기 지저분한 것같아요.
개인적으로 CSS module 방식을 선호하고 있었는데, 다른 좋은 방법이나 코드를 깔끔하게 개선할 수 있는 방법이 있는지 좀 찾아보겠습니당.
좋은 의견이 있다면 말해주세요!
